### PR TITLE
fix: gracefully handle connection issue during tracerouting

### DIFF
--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -107,8 +107,8 @@ class MeshtasticMQTTHandler:
 
         # Pass configuration parameters directly to TracerouteManager
         self.traceroute_manager = TracerouteManager(
-            self.connection_manager.get_interface(),
             self.node_cache,
+            self.connection_manager,
             traceroute_cooldown,
             traceroute_interval,
             traceroute_max_retries,
@@ -141,14 +141,11 @@ class MeshtasticMQTTHandler:
         logging.debug(f"Message published: {mid}")
 
     def _update_interface_references(self) -> None:
-        """Update interface references in NodeCache and TracerouteManager after reconnection"""
+        """Update interface references in NodeCache after reconnection"""
         interface = self.connection_manager.get_interface()
         if interface:
             self.node_cache.interface = interface
-            self.traceroute_manager.interface = interface
-            logging.info(
-                "Updated interface references in NodeCache and TracerouteManager"
-            )
+            logging.info("Updated interface reference in NodeCache")
 
     def _update_cache_from_packet(self, packet: dict[str, Any]) -> None:
         """

--- a/nhmesh_producer/utils/connection_manager.py
+++ b/nhmesh_producer/utils/connection_manager.py
@@ -47,9 +47,9 @@ class ConnectionManager:
                     try:
                         self.interface.close()
                     except Exception as e:
-                        logging.warning(f"Error closing existing interface: {e}")
+                        logging.warning(f"[ConnectionManager] Error closing existing interface: {e}")
 
-                logging.info(f"Connecting to Meshtastic node at {self.node_ip}")
+                logging.info(f"[ConnectionManager] Connecting to Meshtastic node at {self.node_ip}")
                 self.interface = meshtastic.tcp_interface.TCPInterface(
                     hostname=self.node_ip
                 )
@@ -66,13 +66,15 @@ class ConnectionManager:
                 self.connection_errors = 0
                 self.last_heartbeat = time.time()
 
-                logging.info(f"Successfully connected to node {self.connected_node_id}")
+                logging.info(f"[ConnectionManager] Successfully connected to node {self.connected_node_id}")
+                logging.info(f"[ConnectionManager] Connection state: connected={self.connected}, errors={self.connection_errors}")
                 return True
 
             except Exception as e:
-                logging.warning(f"Failed to connect to Meshtastic node: {e}")
+                logging.warning(f"[ConnectionManager] Failed to connect to Meshtastic node: {e}")
                 self.connected = False
                 self.connection_errors += 1
+                logging.info(f"[ConnectionManager] Connection failed - state: connected={self.connected}, errors={self.connection_errors}")
                 # Clean up any partially created interface
                 if self.interface:
                     try:
@@ -87,53 +89,56 @@ class ConnectionManager:
         attempts = 0
         while attempts < self.reconnect_attempts and not self.stop_event.is_set():
             attempts += 1
-            logging.info(f"Reconnection attempt {attempts}/{self.reconnect_attempts}")
+            logging.info(f"[ConnectionManager] Reconnection attempt {attempts}/{self.reconnect_attempts}")
 
             if self.connect():
                 return True
 
             # Check if shutdown was requested
             if self.stop_event.is_set():
-                logging.info("Shutdown requested during reconnection, aborting")
+                logging.info("[ConnectionManager] Shutdown requested during reconnection, aborting")
                 break
 
             # Exponential backoff with interruptible wait
             delay = self.reconnect_delay * (2 ** (attempts - 1))
             logging.info(
-                f"Reconnection failed, waiting {delay} seconds before next attempt"
+                f"[ConnectionManager] Reconnection failed, waiting {delay} seconds before next attempt"
             )
 
             # Use interruptible wait instead of time.sleep
             if self.stop_event.wait(timeout=delay):
-                logging.info("Shutdown requested during reconnection delay, aborting")
+                logging.info("[ConnectionManager] Shutdown requested during reconnection delay, aborting")
                 break
 
         if self.stop_event.is_set():
-            logging.info("Reconnection aborted due to shutdown")
+            logging.info("[ConnectionManager] Reconnection aborted due to shutdown")
         else:
-            logging.error("Max reconnection attempts reached")
+            logging.error("[ConnectionManager] Max reconnection attempts reached")
         return False
 
     def _health_monitor(self) -> None:
         """Monitor connection health and trigger reconnection if needed"""
+        logging.info(f"[ConnectionManager] Health monitor starting with {self.health_check_interval}s interval")
         while not self.stop_event.is_set():
             try:
                 # Use wait() instead of sleep() so it's interruptible
                 if self.stop_event.wait(timeout=self.health_check_interval):
                     # Event was set (shutdown requested), exit gracefully
-                    logging.info("Health monitor received shutdown signal, exiting")
+                    logging.info("[ConnectionManager] Health monitor received shutdown signal, exiting")
                     break
 
                 # Only continue if not shutting down
                 if self.stop_event.is_set():
                     break
 
+                logging.info(f"[ConnectionManager] Health monitor running check - connected: {self.connected}, errors: {self.connection_errors}/{self.max_connection_errors}")
+
                 if (
                     not self.connected
                     or self.connection_errors >= self.max_connection_errors
                 ):
                     logging.warning(
-                        "Connection health check failed, attempting reconnection"
+                        f"[ConnectionManager] Connection health check failed - connected: {self.connected}, errors: {self.connection_errors}, attempting reconnection"
                     )
                     # Don't attempt reconnection if shutting down
                     if not self.stop_event.is_set():
@@ -142,12 +147,13 @@ class ConnectionManager:
                 # Check if interface is still responsive
                 if self.interface and self.connected and not self.stop_event.is_set():
                     try:
+                        logging.info("[ConnectionManager] Performing interface responsiveness check...")
                         # Simple health check - try to get node info
                         self.interface.getMyNodeInfo()
                         self.last_heartbeat = time.time()
-                        logging.debug("Health check passed")
+                        logging.info("[ConnectionManager] Health check passed - interface responsive")
                     except (BrokenPipeError, ConnectionResetError, OSError) as e:
-                        logging.warning(f"Connection lost during health check: {e}")
+                        logging.warning(f"[ConnectionManager] Connection lost during health check: {e}")
                         self.connected = False
                         self.connection_errors += 1
                         # Force close the interface to clean up internal threads
@@ -157,18 +163,27 @@ class ConnectionManager:
                             pass
                         self.interface = None
                     except Exception as e:
-                        logging.warning(f"Health check failed: {e}")
+                        logging.warning(f"[ConnectionManager] Health check failed: {e}")
                         self.connected = False
                         self.connection_errors += 1
+                else:
+                    if not self.interface:
+                        logging.info("[ConnectionManager] Health check skipped - no interface")
+                    elif not self.connected:
+                        logging.info("[ConnectionManager] Health check skipped - not connected")
+                    else:
+                        logging.info("[ConnectionManager] Health check skipped - shutdown requested")
 
             except Exception as e:
-                logging.error(f"Error in health monitor: {e}")
+                logging.error(f"[ConnectionManager] Error in health monitor: {e}")
 
-        logging.info("Health monitor thread exiting cleanly")
+        logging.info("[ConnectionManager] Health monitor thread exiting cleanly")
 
     def is_connected(self) -> bool:
         """Check if currently connected"""
-        return self.connected and self.interface is not None
+        result = self.connected and self.interface is not None
+        logging.info(f"[ConnectionManager] is_connected() = {result} (connected={self.connected}, interface={'exists' if self.interface else 'None'})")
+        return result
 
     def get_interface(self) -> Any | None:
         """Get the current interface, reconnecting if necessary"""
@@ -185,31 +200,82 @@ class ConnectionManager:
             The interface if available and connected, None if unavailable
         """
         if not self.is_connected():
-            logging.info("Interface not connected, attempting reconnection...")
+            logging.warning("[ConnectionManager] Interface not connected, attempting reconnection...")
             if not self.reconnect():
-                logging.warning("Interface reconnection failed, no interface available")
+                logging.error("[ConnectionManager] Interface reconnection failed, no interface available")
                 return None
+
+        # Do a quick responsiveness check before returning the interface
+        try:
+            if self.interface:
+                self.interface.getMyNodeInfo()
+                return self.interface
+        except (BrokenPipeError, ConnectionResetError, OSError) as e:
+            logging.warning(f"[ConnectionManager] Interface became unresponsive during check: {e}")
+            self.connected = False
+            self.connection_errors += 1
+            # Force close the interface to clean up internal threads
+            try:
+                self.interface.close()
+            except Exception:
+                pass
+            self.interface = None
+
+            # Try to reconnect immediately
+            logging.warning("[ConnectionManager] Attempting immediate reconnection after interface failure...")
+            if self.reconnect():
+                return self.interface
+            else:
+                logging.error("[ConnectionManager] Immediate reconnection failed")
+                return None
+        except Exception as e:
+            logging.warning(f"[ConnectionManager] Interface check failed with unexpected error: {e}")
+            self.connected = False
+            self.connection_errors += 1
+            return None
 
         return self.interface
 
+    def notify_connection_error(self, error: Exception) -> None:
+        """
+        Notify the connection manager of a connection error that occurred during operations.
+        This allows immediate detection of connection issues rather than waiting for health checks.
+
+        Args:
+            error: The exception that occurred during the operation
+        """
+        if isinstance(error, BrokenPipeError | ConnectionResetError | OSError):
+            logging.warning(f"[ConnectionManager] Connection error reported: {error}")
+            self.connected = False
+            self.connection_errors += 1
+            # Force close the interface to clean up internal threads
+            if self.interface:
+                try:
+                    self.interface.close()
+                except Exception:
+                    pass
+                self.interface = None
+        else:
+            logging.info(f"[ConnectionManager] Non-connection error reported: {error}")
+
     def close(self) -> None:
         """Close the connection and stop monitoring"""
-        logging.info("ConnectionManager closing...")
+        logging.info("[ConnectionManager] ConnectionManager closing...")
         self.stop_event.set()
 
         # Wait for health monitor thread to finish
         if hasattr(self, "health_thread") and self.health_thread.is_alive():
-            logging.info("Waiting for health monitor thread to finish...")
+            logging.info("[ConnectionManager] Waiting for health monitor thread to finish...")
             self.health_thread.join(timeout=2.0)  # 2 second timeout
             if self.health_thread.is_alive():
-                logging.warning("Health monitor thread did not finish cleanly")
+                logging.warning("[ConnectionManager] Health monitor thread did not finish cleanly")
             else:
-                logging.info("Health monitor thread finished cleanly")
+                logging.info("[ConnectionManager] Health monitor thread finished cleanly")
 
         if self.interface:
             try:
                 self.interface.close()
-                logging.info("Interface closed successfully")
+                logging.info("[ConnectionManager] Interface closed successfully")
             except Exception as e:
-                logging.error(f"Error closing interface during shutdown: {e}")
+                logging.error(f"[ConnectionManager] Error closing interface during shutdown: {e}")
         self.connected = False

--- a/nhmesh_producer/utils/connection_manager.py
+++ b/nhmesh_producer/utils/connection_manager.py
@@ -70,7 +70,7 @@ class ConnectionManager:
                 return True
 
             except Exception as e:
-                logging.error(f"Failed to connect to Meshtastic node: {e}")
+                logging.warning(f"Failed to connect to Meshtastic node: {e}")
                 self.connected = False
                 self.connection_errors += 1
                 return False
@@ -159,6 +159,21 @@ class ConnectionManager:
                 return None
         return self.interface
 
+    def get_ready_interface(self) -> Any | None:
+        """
+        Get an interface that's ready for operations.
+
+        Returns:
+            The interface if available and connected, None if unavailable
+        """
+        if not self.is_connected():
+            logging.info("Interface not connected, attempting reconnection...")
+            if not self.reconnect():
+                logging.warning("Interface reconnection failed, no interface available")
+                return None
+
+        return self.interface
+
     def close(self) -> None:
         """Close the connection and stop monitoring"""
         logging.info("ConnectionManager closing...")
@@ -178,5 +193,5 @@ class ConnectionManager:
                 self.interface.close()
                 logging.info("Interface closed successfully")
             except Exception as e:
-                logging.warning(f"Error closing interface: {e}")
+                logging.error(f"Error closing interface during shutdown: {e}")
         self.connected = False

--- a/nhmesh_producer/utils/traceroute_manager.py
+++ b/nhmesh_producer/utils/traceroute_manager.py
@@ -488,6 +488,8 @@ class TracerouteManager:
             logging.info(
                 f"[Traceroute] Interface error during traceroute for node {node_id}: {e}"
             )
+            # Notify connection manager of the error for immediate handling
+            self.connection_manager.notify_connection_error(e)
             return "connection_error"
 
     def _traceroute_worker(self) -> None:


### PR DESCRIPTION
When the `ConnectionManager` is handling a disconnected node and actively trying to reconnect, if a traceroute runs the process dies because of an unhandled exception. This handles the case where a bad connection state exists and a node is attempted to be tracerouted. This was reported in #2.

This change logs the error and throws the node back onto the queue so it can be processed when the node reconnects successfully. Note that it _does not_ mark the traceroute as a failure in the backoff logic. We just sling it onto the queue in the hopes the connection is resumed.

I also refactored the traceroute logic a bit because we were crossing responsibility across the ConnectionManager class and TracerouteManager. This should give a little more separation in the logic.