### PR TITLE
feat: add modem preset and lora channel to mqtt messages

### DIFF
--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -86,7 +86,7 @@ class MeshtasticMQTTHandler:
         interface = self.connection_manager.get_interface()
         if interface is None:
             raise Exception("Failed to get Meshtastic interface")
-        
+
         # Get LoRa configuration with null checks
         try:
             self.lora_config = interface.localNode.localConfig.lora
@@ -124,7 +124,7 @@ class MeshtasticMQTTHandler:
         interface = self.connection_manager.get_interface()
         if interface is None:
             raise Exception("Failed to get Meshtastic interface for NodeCache and TracerouteManager")
-        
+
         self.node_cache = NodeCache(interface)
 
         # Pass configuration parameters directly to TracerouteManager

--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -81,6 +81,9 @@ class MeshtasticMQTTHandler:
 
         # Initialize connection manager
         self.connection_manager = ConnectionManager(node_ip)
+        self.lora_config = self.connection_manager.get_interface().localNode.localConfig.lora
+        self.modem_preset = "LongFast" if self.lora_config.modem_preset == 0 else "MediumFast" if self.lora_config.modem_preset == 4 else "Unknown"
+        self.channel_num = self.lora_config.channel_num
 
         # MQTT client setup with callbacks
         self.mqtt_client = mqtt.Client()
@@ -321,6 +324,8 @@ class MeshtasticMQTTHandler:
                 out_packet["gatewayId"] = "unknown"
 
         out_packet["source"] = "rf"
+        out_packet["modem_preset"] = self.modem_preset
+        out_packet["channel_num"] = self.channel_num
 
         self.publish_dict_to_mqtt(out_packet)
 

--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -81,7 +81,7 @@ class MeshtasticMQTTHandler:
 
         # Initialize connection manager
         self.connection_manager = ConnectionManager(node_ip)
-        
+
         # Get interface and check if it's available
         interface = self.connection_manager.get_interface()
         if interface is None:

--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -90,7 +90,13 @@ class MeshtasticMQTTHandler:
         # Get LoRa configuration with null checks
         try:
             self.lora_config = interface.localNode.localConfig.lora
-            self.modem_preset = "LongFast" if self.lora_config.modem_preset == 0 else "MediumFast" if self.lora_config.modem_preset == 4 else "Unknown"
+            self.modem_preset = (
+                "LongFast"
+                if self.lora_config.modem_preset == 0
+                else "MediumFast"
+                if self.lora_config.modem_preset == 4
+                else "Unknown"
+            )
             self.channel_num = self.lora_config.channel_num
         except AttributeError as e:
             logging.warning(f"Failed to get LoRa configuration: {e}")
@@ -123,7 +129,9 @@ class MeshtasticMQTTHandler:
         # Get interface for NodeCache and TracerouteManager initialization
         interface = self.connection_manager.get_interface()
         if interface is None:
-            raise Exception("Failed to get Meshtastic interface for NodeCache and TracerouteManager")
+            raise Exception(
+                "Failed to get Meshtastic interface for NodeCache and TracerouteManager"
+            )
 
         self.node_cache = NodeCache(interface)
 


### PR DESCRIPTION
Adds

```
...
  "modem_preset": "LongFast",
  "channel_num": 0
```

to MQTT messages to support multi-preset telemetry and display on the website.