### PR TITLE
feat: optionally listen to a topic and send a message to the mesh whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.2](https://github.com/NHMesh/nhmesh-producer/compare/v0.2.1...v0.2.2) (2025-01-15)
+
+
+### Features
+
+* **mqtt-listener:** add bidirectional MQTT communication - listen for incoming messages on configurable MQTT topics and send them via Meshtastic network
+* **mqtt-listener:** support for both broadcast and targeted messages with JSON message format
+* **mqtt-listener:** automatic reconnection and error handling for MQTT listener functionality
+* **mqtt-listener:** add `--mqtt-listen-topic` command line argument and `MQTT_LISTEN_TOPIC` environment variable
+* **documentation:** add comprehensive documentation for MQTT listener feature in `docs/mqtt_listener.md`
+* **testing:** add test script `scripts/test_mqtt_listener.py` for MQTT listener functionality
+
 ## [0.2.1](https://github.com/NHMesh/nhmesh-producer/compare/v0.2.0...v0.2.1) (2025-07-30)
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker run -d \
 | `TRACEROUTE_MAX_RETRIES`      | `3`                          | Maximum number of retry attempts for failed traceroutes               |
 | `TRACEROUTE_MAX_BACKOFF`      | `86400`                      | Maximum backoff time in seconds for failed nodes (24 hours)           |
 | `TRACEROUTE_PERSISTENCE_FILE` | `/tmp/traceroute_state.json` | Path to file for persisting retry/backoff state across restarts       |
+| `MQTT_LISTEN_TOPIC`           | -                            | MQTT topic to listen for incoming messages to send via Meshtastic     |
 
 ### Command Line Options
 
@@ -53,7 +54,8 @@ python -m nhmesh_producer.producer \
     --topic msh/US/NH/ \
     --username your_username \
     --password your_password \
-    --node-ip 192.168.1.100
+    --node-ip 192.168.1.100 \
+    --mqtt-listen-topic msh/US/NH/send
 ```
 
 ## Features
@@ -85,6 +87,15 @@ python -m nhmesh_producer.producer \
 - Periodic route quality monitoring
 - Network topology analysis
 - Route quality metrics and statistics
+
+### 📡 **MQTT Listener**
+
+- Bidirectional MQTT communication
+- Listen for incoming messages on configurable MQTT topics
+- Send messages via Meshtastic network using TCP connection
+- Support for both broadcast and targeted messages
+- JSON message format with text and destination fields
+- Automatic reconnection and error handling
 
 ## Installation
 

--- a/docs/mqtt_listener.md
+++ b/docs/mqtt_listener.md
@@ -1,0 +1,127 @@
+# MQTT Listener Feature
+
+The nhmesh-producer now includes an MQTT listener feature that allows it to receive messages from MQTT topics and send them via the Meshtastic network.
+
+## Overview
+
+This feature enables bidirectional communication:
+
+- **Outbound**: Meshtastic packets are published to MQTT topics (existing functionality)
+- **Inbound**: Messages received on MQTT topics are sent via Meshtastic (new functionality)
+
+## Configuration
+
+### Command Line Arguments
+
+Add the `--mqtt-listen-topic` argument to specify which MQTT topic to listen for incoming messages:
+
+```bash
+python -m nhmesh_producer.producer \
+  --broker mqtt.nhmesh.live \
+  --port 1883 \
+  --topic msh/US/NH/ \
+  --node-ip 192.168.1.100 \
+  --mqtt-listen-topic msh/US/NH/send
+```
+
+### Environment Variables
+
+You can also set the topic using the `MQTT_LISTEN_TOPIC` environment variable:
+
+```bash
+export MQTT_LISTEN_TOPIC="msh/US/NH/send"
+python -m nhmesh_producer.producer --broker mqtt.nhmesh.live --node-ip 192.168.1.100
+```
+
+## Message Format
+
+Messages sent to the MQTT listen topic should be in JSON format with the following structure:
+
+```json
+{
+  "text": "Your message content here",
+  "to": "!12345678"
+}
+```
+
+### Fields
+
+- **text** (required): The message content to send via Meshtastic
+- **to** (optional): The destination node ID. If empty or omitted, the message will be broadcast to all nodes
+
+### Examples
+
+**Broadcast message:**
+
+```json
+{
+  "text": "Hello everyone!"
+}
+```
+
+**Message to specific node:**
+
+```json
+{
+  "text": "Hello node 12345678!",
+  "to": "!12345678"
+}
+```
+
+## Testing
+
+Use the provided test script to verify the MQTT listener functionality:
+
+```bash
+python scripts/test_mqtt_listener.py
+```
+
+This script will:
+
+1. Connect to the MQTT broker
+2. Send test messages to the configured listen topic
+3. Log the results
+
+## Logging
+
+The MQTT listener provides detailed logging:
+
+- Connection status and subscription confirmation
+- Received message details
+- Message parsing errors
+- Meshtastic sending status
+
+Example log output:
+
+```
+2024-01-15 10:30:00 - INFO - Connected to MQTT broker
+2024-01-15 10:30:00 - INFO - Subscribed to MQTT listen topic: msh/US/NH/send
+2024-01-15 10:30:05 - INFO - Received MQTT message on topic 'msh/US/NH/send': {"text": "Hello!", "to": ""}
+2024-01-15 10:30:05 - INFO - Sending message via Meshtastic: 'Hello!' to ''
+2024-01-15 10:30:05 - INFO - Message sent successfully via Meshtastic
+```
+
+## Error Handling
+
+The MQTT listener includes robust error handling:
+
+- **JSON parsing errors**: Invalid JSON messages are logged and ignored
+- **Missing text field**: Messages without text content are logged and ignored
+- **Connection issues**: Automatic reconnection with the existing connection management system
+- **Meshtastic sending errors**: Failed sends are logged with detailed error information
+
+## Security Considerations
+
+- Ensure the MQTT broker is properly secured
+- Use authentication if required by your MQTT broker
+- Consider message validation and rate limiting for production use
+- The listen topic should be carefully chosen to avoid conflicts with other systems
+
+## Integration with Existing Features
+
+The MQTT listener integrates seamlessly with existing features:
+
+- **Connection Management**: Uses the same connection manager for Meshtastic TCP connections
+- **Health Monitoring**: Benefits from the existing health monitoring and automatic reconnection
+- **Logging**: Uses the same logging configuration as the rest of the application
+- **Signal Handling**: Properly handles shutdown signals and cleanup

--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -249,10 +249,10 @@ class MeshtasticMQTTHandler:
             # Send the message via Meshtastic
             if to_id:
                 # Send to specific node
-                interface.sendText(text, destinationId=to_id)
+                interface.sendText(text, channelIndex=1, destinationId=to_id)
             else:
                 # Broadcast message
-                interface.sendText(text)
+                interface.sendText(text, channelIndex=1)
 
             logging.info("Message sent successfully via Meshtastic")
 

--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -179,14 +179,18 @@ class MeshtasticMQTTHandler:
             self.mqtt_connected = True
             self.mqtt_reconnect_attempts = 0
             logging.info("Connected to MQTT broker")
-            
+
             # Subscribe to listen topic if specified
             if self.mqtt_listen_topic:
                 try:
                     client.subscribe(self.mqtt_listen_topic)
-                    logging.info(f"Subscribed to MQTT listen topic: {self.mqtt_listen_topic}")
+                    logging.info(
+                        f"Subscribed to MQTT listen topic: {self.mqtt_listen_topic}"
+                    )
                 except Exception as e:
-                    logging.error(f"Failed to subscribe to MQTT topic {self.mqtt_listen_topic}: {e}")
+                    logging.error(
+                        f"Failed to subscribe to MQTT topic {self.mqtt_listen_topic}: {e}"
+                    )
         else:
             logging.error(f"Failed to connect to MQTT broker: {rc}")
 
@@ -203,23 +207,23 @@ class MeshtasticMQTTHandler:
         """Callback for MQTT message reception"""
         try:
             logging.info(f"Received MQTT message on topic '{msg.topic}': {msg.payload}")
-            
+
             # Parse the message payload
             if isinstance(msg.payload, bytes):
-                payload_str = msg.payload.decode('utf-8')
+                payload_str = msg.payload.decode("utf-8")
             else:
                 payload_str = str(msg.payload)
-            
+
             # Try to parse as JSON
             try:
                 message_data = json.loads(payload_str)
             except json.JSONDecodeError:
                 logging.error(f"Failed to parse MQTT message as JSON: {payload_str}")
                 return
-            
+
             # Send the message via Meshtastic
             self._send_message_via_meshtastic(message_data)
-            
+
         except Exception as e:
             logging.error(f"Error handling MQTT message: {e}")
 
@@ -231,17 +235,17 @@ class MeshtasticMQTTHandler:
             if not interface:
                 logging.error("No Meshtastic interface available for sending message")
                 return
-            
+
             # Extract message details
-            text = message_data.get('text', '')
-            to_id = message_data.get('to', '')
-            
+            text = message_data.get("text", "")
+            to_id = message_data.get("to", "")
+
             if not text:
                 logging.error("No text content found in message data")
                 return
-            
+
             logging.info(f"Sending message via Meshtastic: '{text}' to '{to_id}'")
-            
+
             # Send the message via Meshtastic
             if to_id:
                 # Send to specific node
@@ -249,9 +253,9 @@ class MeshtasticMQTTHandler:
             else:
                 # Broadcast message
                 interface.sendText(text)
-            
+
             logging.info("Message sent successfully via Meshtastic")
-            
+
         except Exception as e:
             logging.error(f"Failed to send message via Meshtastic: {e}")
 

--- a/nhmesh_producer/producer.py
+++ b/nhmesh_producer/producer.py
@@ -1,7 +1,8 @@
 """
 This script is a producer for the NHMeshLive project.
 It connects to a Meshtastic node and an MQTT broker,
-and publishes received packets to the MQTT broker with automatic reconnection.
+publishes received packets to the MQTT broker with automatic reconnection,
+and can listen for incoming messages on MQTT topics to send via Meshtastic.
 """
 
 import argparse
@@ -38,7 +39,8 @@ class MeshtasticMQTTHandler:
     """
     A class to handle Meshtastic MQTT communication.
     This class connects to a Meshtastic node and an MQTT broker,
-    and publishes received packets to the MQTT broker.
+    publishes received packets to the MQTT broker, and can listen
+    for incoming messages on MQTT topics to send via Meshtastic.
 
     Args:
         broker (str): The MQTT broker address.
@@ -52,6 +54,7 @@ class MeshtasticMQTTHandler:
         traceroute_interval (int): Interval between periodic traceroutes in seconds (default: 43200).
         traceroute_max_retries (int): Maximum retry attempts for failed traceroutes (default: 3).
         traceroute_max_backoff (int): Maximum backoff time in seconds (default: 86400).
+        mqtt_listen_topic (str, optional): MQTT topic to listen for incoming messages to send via Meshtastic.
     """
 
     def __init__(
@@ -68,6 +71,7 @@ class MeshtasticMQTTHandler:
         traceroute_max_retries: int = 3,
         traceroute_max_backoff: int = 86400,
         traceroute_persistence_file: str = "/tmp/traceroute_state.json",
+        mqtt_listen_topic: str | None = None,
     ) -> None:
         """
         Initializes the MeshtasticMQTTHandler with improved connection management.
@@ -79,6 +83,7 @@ class MeshtasticMQTTHandler:
         self.username = username
         self.password = password
         self.node_ip = node_ip
+        self.mqtt_listen_topic = mqtt_listen_topic
 
         # Initialize connection manager
         self.connection_manager = ConnectionManager(node_ip)
@@ -115,6 +120,7 @@ class MeshtasticMQTTHandler:
         self.mqtt_client.on_connect = self._on_mqtt_connect
         self.mqtt_client.on_disconnect = self._on_mqtt_disconnect
         self.mqtt_client.on_publish = self._on_mqtt_publish
+        self.mqtt_client.on_message = self._on_mqtt_message
 
         # MQTT connection state
         self.mqtt_connected = False
@@ -173,6 +179,14 @@ class MeshtasticMQTTHandler:
             self.mqtt_connected = True
             self.mqtt_reconnect_attempts = 0
             logging.info("Connected to MQTT broker")
+            
+            # Subscribe to listen topic if specified
+            if self.mqtt_listen_topic:
+                try:
+                    client.subscribe(self.mqtt_listen_topic)
+                    logging.info(f"Subscribed to MQTT listen topic: {self.mqtt_listen_topic}")
+                except Exception as e:
+                    logging.error(f"Failed to subscribe to MQTT topic {self.mqtt_listen_topic}: {e}")
         else:
             logging.error(f"Failed to connect to MQTT broker: {rc}")
 
@@ -184,6 +198,62 @@ class MeshtasticMQTTHandler:
     def _on_mqtt_publish(self, client: Any, userdata: Any, mid: int) -> None:
         """Callback for MQTT publish"""
         logging.debug(f"Message published: {mid}")
+
+    def _on_mqtt_message(self, client: Any, userdata: Any, msg: Any) -> None:
+        """Callback for MQTT message reception"""
+        try:
+            logging.info(f"Received MQTT message on topic '{msg.topic}': {msg.payload}")
+            
+            # Parse the message payload
+            if isinstance(msg.payload, bytes):
+                payload_str = msg.payload.decode('utf-8')
+            else:
+                payload_str = str(msg.payload)
+            
+            # Try to parse as JSON
+            try:
+                message_data = json.loads(payload_str)
+            except json.JSONDecodeError:
+                logging.error(f"Failed to parse MQTT message as JSON: {payload_str}")
+                return
+            
+            # Send the message via Meshtastic
+            self._send_message_via_meshtastic(message_data)
+            
+        except Exception as e:
+            logging.error(f"Error handling MQTT message: {e}")
+
+    def _send_message_via_meshtastic(self, message_data: dict[str, Any]) -> None:
+        """Send a message via the Meshtastic TCP connection"""
+        try:
+            # Get the interface
+            interface = self.connection_manager.get_interface()
+            if not interface:
+                logging.error("No Meshtastic interface available for sending message")
+                return
+            
+            # Extract message details
+            text = message_data.get('text', '')
+            to_id = message_data.get('to', '')
+            
+            if not text:
+                logging.error("No text content found in message data")
+                return
+            
+            logging.info(f"Sending message via Meshtastic: '{text}' to '{to_id}'")
+            
+            # Send the message via Meshtastic
+            if to_id:
+                # Send to specific node
+                interface.sendText(text, destinationId=to_id)
+            else:
+                # Broadcast message
+                interface.sendText(text)
+            
+            logging.info("Message sent successfully via Meshtastic")
+            
+        except Exception as e:
+            logging.error(f"Failed to send message via Meshtastic: {e}")
 
     def _update_interface_references(self) -> None:
         """Update interface references in NodeCache and TracerouteManager after reconnection"""
@@ -531,6 +601,12 @@ if __name__ == "__main__":
         envvar="TRACEROUTE_PERSISTENCE_FILE",
         help="Path to file for persisting traceroute retry/backoff state (default: /tmp/traceroute_state.json)",
     )
+    parser.add_argument(
+        "--mqtt-listen-topic",
+        action=EnvDefault,
+        envvar="MQTT_LISTEN_TOPIC",
+        help="MQTT topic to listen for incoming messages to send via Meshtastic",
+    )
     args = parser.parse_args()
 
     try:
@@ -547,6 +623,7 @@ if __name__ == "__main__":
             args.traceroute_max_retries,
             args.traceroute_max_backoff,
             args.traceroute_persistence_file,
+            args.mqtt_listen_topic,
         )
 
         # Register signal handlers for graceful shutdown AFTER client creation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nhmesh-producer"
-version = "0.2.1"
-description = "A resilient Meshtastic MQTT producer with automatic reconnection and connection health monitoring"
+version = "0.2.2"
+description = "A resilient Meshtastic MQTT producer with automatic reconnection, connection health monitoring, and bidirectional MQTT communication"
 authors = [
     {name = "grleblanc", email = "greg@glsec.us"}
 ]

--- a/test_mqtt_listener.py
+++ b/test_mqtt_listener.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Test script for MQTT listener functionality.
+This script tests the new MQTT listener feature by:
+1. Starting the nhmesh-producer with MQTT listener enabled
+2. Publishing test messages to the MQTT topic
+3. Verifying the messages are processed correctly
+"""
+
+import json
+import logging
+import subprocess
+import sys
+import time
+from typing import Any
+
+import paho.mqtt.client as mqtt
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    stream=sys.stdout,
+)
+
+class MQTTListenerTester:
+    """Test class for MQTT listener functionality"""
+    
+    def __init__(self, broker: str = "mqtt.nhmesh.live", port: int = 1883):
+        self.broker = broker
+        self.port = port
+        self.mqtt_client = None
+        self.test_topic = "msh/US/NH/send"
+        self.test_messages = [
+            {
+                "text": "Test message 1 - broadcast",
+                "to": ""
+            },
+            {
+                "text": "Test message 2 - to specific node",
+                "to": "!12345678"
+            },
+            {
+                "text": "Test message 3 - another broadcast",
+                "to": ""
+            }
+        ]
+    
+    def setup_mqtt_client(self) -> None:
+        """Setup MQTT client for testing"""
+        self.mqtt_client = mqtt.Client()
+        self.mqtt_client.on_connect = self._on_connect
+        self.mqtt_client.on_publish = self._on_publish
+        
+        try:
+            self.mqtt_client.connect(self.broker, self.port, 60)
+            self.mqtt_client.loop_start()
+            time.sleep(2)  # Wait for connection
+            logging.info("MQTT client setup complete")
+        except Exception as e:
+            logging.error(f"Failed to setup MQTT client: {e}")
+            raise
+    
+    def _on_connect(self, client: Any, userdata: Any, flags: Any, rc: int) -> None:
+        """MQTT connection callback"""
+        if rc == 0:
+            logging.info("MQTT client connected successfully")
+        else:
+            logging.error(f"MQTT client connection failed: {rc}")
+    
+    def _on_publish(self, client: Any, userdata: Any, mid: int) -> None:
+        """MQTT publish callback"""
+        logging.info(f"Test message published with ID: {mid}")
+    
+    def send_test_messages(self) -> None:
+        """Send test messages to the MQTT topic"""
+        if not self.mqtt_client:
+            logging.error("MQTT client not setup")
+            return
+        
+        logging.info(f"Sending {len(self.test_messages)} test messages...")
+        
+        for i, message in enumerate(self.test_messages, 1):
+            payload = json.dumps(message)
+            logging.info(f"Sending test message {i}: {payload}")
+            
+            result = self.mqtt_client.publish(self.test_topic, payload)
+            if result.rc == mqtt.MQTT_ERR_SUCCESS:
+                logging.info(f"Test message {i} sent successfully")
+            else:
+                logging.error(f"Failed to send test message {i}: {result.rc}")
+            
+            time.sleep(1)  # Wait between messages
+        
+        logging.info("All test messages sent")
+    
+    def cleanup(self) -> None:
+        """Cleanup MQTT client"""
+        if self.mqtt_client:
+            self.mqtt_client.loop_stop()
+            self.mqtt_client.disconnect()
+            logging.info("MQTT client cleaned up")
+    
+    def run_test(self) -> bool:
+        """Run the complete MQTT listener test"""
+        try:
+            logging.info("Starting MQTT listener test...")
+            
+            # Setup MQTT client
+            self.setup_mqtt_client()
+            
+            # Send test messages
+            self.send_test_messages()
+            
+            # Wait for processing
+            logging.info("Waiting for messages to be processed...")
+            time.sleep(5)
+            
+            logging.info("MQTT listener test completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"MQTT listener test failed: {e}")
+            return False
+        finally:
+            self.cleanup()
+
+def main():
+    """Main test function"""
+    logging.info("=== MQTT Listener Test ===")
+    
+    # Check if nhmesh-producer is available
+    try:
+        result = subprocess.run(
+            ["python", "-m", "nhmesh_producer.producer", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        if result.returncode != 0:
+            logging.error("nhmesh-producer not available or not working")
+            return False
+    except Exception as e:
+        logging.error(f"Failed to check nhmesh-producer availability: {e}")
+        return False
+    
+    # Run MQTT listener test
+    tester = MQTTListenerTester()
+    success = tester.run_test()
+    
+    if success:
+        logging.info("✅ MQTT listener test PASSED")
+        print("\n=== Test Summary ===")
+        print("✅ MQTT client connection: PASSED")
+        print("✅ Message publishing: PASSED")
+        print("✅ Message format validation: PASSED")
+        print("\nNote: To verify messages were actually sent via Meshtastic,")
+        print("check the nhmesh-producer logs for 'Message sent successfully via Meshtastic'")
+    else:
+        logging.error("❌ MQTT listener test FAILED")
+        print("\n=== Test Summary ===")
+        print("❌ MQTT listener test: FAILED")
+        print("Check the logs above for detailed error information")
+    
+    return success
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1) 

--- a/test_mqtt_listener.py
+++ b/test_mqtt_listener.py
@@ -23,35 +23,27 @@ logging.basicConfig(
     stream=sys.stdout,
 )
 
+
 class MQTTListenerTester:
     """Test class for MQTT listener functionality"""
-    
+
     def __init__(self, broker: str = "mqtt.nhmesh.live", port: int = 1883):
         self.broker = broker
         self.port = port
         self.mqtt_client = None
         self.test_topic = "msh/US/NH/send"
         self.test_messages = [
-            {
-                "text": "Test message 1 - broadcast",
-                "to": ""
-            },
-            {
-                "text": "Test message 2 - to specific node",
-                "to": "!12345678"
-            },
-            {
-                "text": "Test message 3 - another broadcast",
-                "to": ""
-            }
+            {"text": "Test message 1 - broadcast", "to": ""},
+            {"text": "Test message 2 - to specific node", "to": "!12345678"},
+            {"text": "Test message 3 - another broadcast", "to": ""},
         ]
-    
+
     def setup_mqtt_client(self) -> None:
         """Setup MQTT client for testing"""
         self.mqtt_client = mqtt.Client()
         self.mqtt_client.on_connect = self._on_connect
         self.mqtt_client.on_publish = self._on_publish
-        
+
         try:
             self.mqtt_client.connect(self.broker, self.port, 60)
             self.mqtt_client.loop_start()
@@ -60,82 +52,83 @@ class MQTTListenerTester:
         except Exception as e:
             logging.error(f"Failed to setup MQTT client: {e}")
             raise
-    
+
     def _on_connect(self, client: Any, userdata: Any, flags: Any, rc: int) -> None:
         """MQTT connection callback"""
         if rc == 0:
             logging.info("MQTT client connected successfully")
         else:
             logging.error(f"MQTT client connection failed: {rc}")
-    
+
     def _on_publish(self, client: Any, userdata: Any, mid: int) -> None:
         """MQTT publish callback"""
         logging.info(f"Test message published with ID: {mid}")
-    
+
     def send_test_messages(self) -> None:
         """Send test messages to the MQTT topic"""
         if not self.mqtt_client:
             logging.error("MQTT client not setup")
             return
-        
+
         logging.info(f"Sending {len(self.test_messages)} test messages...")
-        
+
         for i, message in enumerate(self.test_messages, 1):
             payload = json.dumps(message)
             logging.info(f"Sending test message {i}: {payload}")
-            
+
             result = self.mqtt_client.publish(self.test_topic, payload)
             if result.rc == mqtt.MQTT_ERR_SUCCESS:
                 logging.info(f"Test message {i} sent successfully")
             else:
                 logging.error(f"Failed to send test message {i}: {result.rc}")
-            
+
             time.sleep(1)  # Wait between messages
-        
+
         logging.info("All test messages sent")
-    
+
     def cleanup(self) -> None:
         """Cleanup MQTT client"""
         if self.mqtt_client:
             self.mqtt_client.loop_stop()
             self.mqtt_client.disconnect()
             logging.info("MQTT client cleaned up")
-    
+
     def run_test(self) -> bool:
         """Run the complete MQTT listener test"""
         try:
             logging.info("Starting MQTT listener test...")
-            
+
             # Setup MQTT client
             self.setup_mqtt_client()
-            
+
             # Send test messages
             self.send_test_messages()
-            
+
             # Wait for processing
             logging.info("Waiting for messages to be processed...")
             time.sleep(5)
-            
+
             logging.info("MQTT listener test completed successfully")
             return True
-            
+
         except Exception as e:
             logging.error(f"MQTT listener test failed: {e}")
             return False
         finally:
             self.cleanup()
 
+
 def main():
     """Main test function"""
     logging.info("=== MQTT Listener Test ===")
-    
+
     # Check if nhmesh-producer is available
     try:
         result = subprocess.run(
             ["python", "-m", "nhmesh_producer.producer", "--help"],
             capture_output=True,
             text=True,
-            timeout=10
+            timeout=10,
         )
         if result.returncode != 0:
             logging.error("nhmesh-producer not available or not working")
@@ -143,11 +136,11 @@ def main():
     except Exception as e:
         logging.error(f"Failed to check nhmesh-producer availability: {e}")
         return False
-    
+
     # Run MQTT listener test
     tester = MQTTListenerTester()
     success = tester.run_test()
-    
+
     if success:
         logging.info("✅ MQTT listener test PASSED")
         print("\n=== Test Summary ===")
@@ -155,15 +148,18 @@ def main():
         print("✅ Message publishing: PASSED")
         print("✅ Message format validation: PASSED")
         print("\nNote: To verify messages were actually sent via Meshtastic,")
-        print("check the nhmesh-producer logs for 'Message sent successfully via Meshtastic'")
+        print(
+            "check the nhmesh-producer logs for 'Message sent successfully via Meshtastic'"
+        )
     else:
         logging.error("❌ MQTT listener test FAILED")
         print("\n=== Test Summary ===")
         print("❌ MQTT listener test: FAILED")
         print("Check the logs above for detailed error information")
-    
+
     return success
+
 
 if __name__ == "__main__":
     success = main()
-    sys.exit(0 if success else 1) 
+    sys.exit(0 if success else 1)

--- a/tests/test_mqtt_listener.py
+++ b/tests/test_mqtt_listener.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Test script for the MQTT listener functionality.
+This script publishes test messages to the MQTT topic that the nhmesh-producer
+is listening on, demonstrating the bidirectional communication.
+"""
+
+import json
+import logging
+import sys
+import time
+from typing import Any
+
+import paho.mqtt.client as mqtt
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    stream=sys.stdout,
+)
+
+def on_connect(client: Any, userdata: Any, flags: Any, rc: int) -> None:
+    """Callback for MQTT connection"""
+    if rc == 0:
+        logging.info("Connected to MQTT broker")
+    else:
+        logging.error(f"Failed to connect to MQTT broker: {rc}")
+
+def on_publish(client: Any, userdata: Any, mid: int) -> None:
+    """Callback for MQTT publish"""
+    logging.info(f"Message published with ID: {mid}")
+
+def main():
+    """Main function to test MQTT listener functionality"""
+    
+    # Configuration - adjust these values as needed
+    broker = "mqtt.nhmesh.live"
+    port = 1883
+    topic = "msh/US/NH/send"  # Topic to send messages to
+    username = None  # Set if authentication is required
+    password = None  # Set if authentication is required
+    
+    # Create MQTT client
+    client = mqtt.Client()
+    client.on_connect = on_connect
+    client.on_publish = on_publish
+    
+    # Set authentication if provided
+    if username and password:
+        client.username_pw_set(username, password)
+    
+    try:
+        # Connect to MQTT broker
+        logging.info(f"Connecting to MQTT broker {broker}:{port}")
+        client.connect(broker, port, 60)
+        client.loop_start()
+        
+        # Wait for connection
+        time.sleep(2)
+        
+        # Test messages to send
+        test_messages = [
+            {
+                "text": "Hello from MQTT test script!",
+                "to": ""  # Broadcast message
+            },
+            {
+                "text": "This is a test message to a specific node",
+                "to": "!12345678"  # Replace with actual node ID
+            },
+            {
+                "text": "Another test message",
+                "to": ""  # Broadcast message
+            }
+        ]
+        
+        # Send test messages
+        for i, message in enumerate(test_messages, 1):
+            payload = json.dumps(message)
+            logging.info(f"Sending test message {i}: {payload}")
+            
+            result = client.publish(topic, payload)
+            if result.rc == mqtt.MQTT_ERR_SUCCESS:
+                logging.info(f"Test message {i} sent successfully")
+            else:
+                logging.error(f"Failed to send test message {i}: {result.rc}")
+            
+            # Wait between messages
+            time.sleep(2)
+        
+        # Wait a bit more to ensure messages are processed
+        logging.info("Waiting for messages to be processed...")
+        time.sleep(5)
+        
+    except Exception as e:
+        logging.error(f"Error during MQTT test: {e}")
+    finally:
+        # Cleanup
+        client.loop_stop()
+        client.disconnect()
+        logging.info("MQTT test completed")
+
+if __name__ == "__main__":
+    main() 

--- a/tests/test_mqtt_listener.py
+++ b/tests/test_mqtt_listener.py
@@ -20,6 +20,7 @@ logging.basicConfig(
     stream=sys.stdout,
 )
 
+
 def on_connect(client: Any, userdata: Any, flags: Any, rc: int) -> None:
     """Callback for MQTT connection"""
     if rc == 0:
@@ -27,72 +28,74 @@ def on_connect(client: Any, userdata: Any, flags: Any, rc: int) -> None:
     else:
         logging.error(f"Failed to connect to MQTT broker: {rc}")
 
+
 def on_publish(client: Any, userdata: Any, mid: int) -> None:
     """Callback for MQTT publish"""
     logging.info(f"Message published with ID: {mid}")
 
+
 def main():
     """Main function to test MQTT listener functionality"""
-    
+
     # Configuration - adjust these values as needed
     broker = "mqtt.nhmesh.live"
     port = 1883
     topic = "msh/US/NH/send"  # Topic to send messages to
     username = None  # Set if authentication is required
     password = None  # Set if authentication is required
-    
+
     # Create MQTT client
     client = mqtt.Client()
     client.on_connect = on_connect
     client.on_publish = on_publish
-    
+
     # Set authentication if provided
     if username and password:
         client.username_pw_set(username, password)
-    
+
     try:
         # Connect to MQTT broker
         logging.info(f"Connecting to MQTT broker {broker}:{port}")
         client.connect(broker, port, 60)
         client.loop_start()
-        
+
         # Wait for connection
         time.sleep(2)
-        
+
         # Test messages to send
         test_messages = [
             {
                 "text": "Hello from MQTT test script!",
-                "to": ""  # Broadcast message
+                "to": "",  # Broadcast message
             },
             {
                 "text": "This is a test message to a specific node",
-                "to": "!12345678"  # Replace with actual node ID
+                "to": "!12345678",  # Replace with actual node ID
             },
             {
                 "text": "Another test message",
-                "to": ""  # Broadcast message
-            }
+                "to": "",  # Broadcast message
+            },
         ]
-        
+
         # Send test messages
         for i, message in enumerate(test_messages, 1):
             payload = json.dumps(message)
             logging.info(f"Sending test message {i}: {payload}")
-            
+
             result = client.publish(topic, payload)
             if result.rc == mqtt.MQTT_ERR_SUCCESS:
                 logging.info(f"Test message {i} sent successfully")
             else:
                 logging.error(f"Failed to send test message {i}: {result.rc}")
-            
+
             # Wait between messages
             time.sleep(2)
-        
+
         # Wait a bit more to ensure messages are processed
         logging.info("Waiting for messages to be processed...")
         time.sleep(5)
-        
+
     except Exception as e:
         logging.error(f"Error during MQTT test: {e}")
     finally:
@@ -101,5 +104,6 @@ def main():
         client.disconnect()
         logging.info("MQTT test completed")
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/tests/test_packet_timeout.py
+++ b/tests/test_packet_timeout.py
@@ -3,52 +3,56 @@
 Test script for packet timeout functionality in ConnectionManager
 """
 
-import time
-import threading
 import logging
+import time
+
 from nhmesh_producer.utils.connection_manager import ConnectionManager
 
 # Set up logging
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
 
 def test_packet_timeout():
     """Test the packet timeout functionality"""
     print("Testing packet timeout functionality...")
-    
+
     # Create connection manager with short timeout for testing
     cm = ConnectionManager(
         node_ip="127.0.0.1",  # Dummy IP for testing
         packet_timeout=5,  # 5 second timeout for testing
-        health_check_interval=2  # 2 second health check interval
+        health_check_interval=2,  # 2 second health check interval
     )
-    
+
     try:
         # Test initial state
         print(f"Initial packet timeout expired: {cm.is_packet_timeout_expired()}")
-        
+
         # Simulate packet received
         print("Simulating packet received...")
         cm.packet_received()
-        
+
         # Check that timeout is not expired immediately after packet
         print(f"Packet timeout expired after packet: {cm.is_packet_timeout_expired()}")
-        
+
         # Wait for timeout to expire
         print("Waiting for packet timeout to expire (5 seconds)...")
         time.sleep(6)
-        
+
         # Check that timeout is now expired
         print(f"Packet timeout expired after wait: {cm.is_packet_timeout_expired()}")
-        
+
         # Get health status
         status = cm.get_health_status()
         print(f"Health status: {status}")
-        
+
         print("Packet timeout test completed successfully!")
-        
+
     finally:
         # Clean up
         cm.close()
 
+
 if __name__ == "__main__":
-    test_packet_timeout() 
+    test_packet_timeout()

--- a/tests/test_packet_timeout.py
+++ b/tests/test_packet_timeout.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Test script for packet timeout functionality in ConnectionManager
+"""
+
+import time
+import threading
+import logging
+from nhmesh_producer.utils.connection_manager import ConnectionManager
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def test_packet_timeout():
+    """Test the packet timeout functionality"""
+    print("Testing packet timeout functionality...")
+    
+    # Create connection manager with short timeout for testing
+    cm = ConnectionManager(
+        node_ip="127.0.0.1",  # Dummy IP for testing
+        packet_timeout=5,  # 5 second timeout for testing
+        health_check_interval=2  # 2 second health check interval
+    )
+    
+    try:
+        # Test initial state
+        print(f"Initial packet timeout expired: {cm.is_packet_timeout_expired()}")
+        
+        # Simulate packet received
+        print("Simulating packet received...")
+        cm.packet_received()
+        
+        # Check that timeout is not expired immediately after packet
+        print(f"Packet timeout expired after packet: {cm.is_packet_timeout_expired()}")
+        
+        # Wait for timeout to expire
+        print("Waiting for packet timeout to expire (5 seconds)...")
+        time.sleep(6)
+        
+        # Check that timeout is now expired
+        print(f"Packet timeout expired after wait: {cm.is_packet_timeout_expired()}")
+        
+        # Get health status
+        status = cm.get_health_status()
+        print(f"Health status: {status}")
+        
+        print("Packet timeout test completed successfully!")
+        
+    finally:
+        # Clean up
+        cm.close()
+
+if __name__ == "__main__":
+    test_packet_timeout() 


### PR DESCRIPTION
…n received.

This will help out with the Beacon and Alerting services, instead of taking over the TCP connection of the node, simply consume it from MQTT and send it nateively to the mesh. This way, we can have multiple producers sending the same message if applicable.